### PR TITLE
Trigger on options pages and ACF. Make toggleable via settings menu

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+  "name": "mattpatterson94/sitesauce-wordpress-plugin",
+  "description": "A fork of the sitesauce wordpress plugin for triggering sitesauce",
+  "homepage": "https://github.com/mattpatterson94/sitesauce-wordpress-plugin",
+  "keywords": [
+    "wordpress"
+  ],
+  "authors": [
+    {
+      "name": "Matt Patterson",
+      "homepage": "https://mattdoesdev.com/"
+    }
+  ],
+  "support": {
+      "issues": "https://github.com/mattpatterson94/sitesauce-wordpress-plugin/issues",
+      "source": "https://github.com/mattpatterson94/sitesauce-wordpress-plugin"
+  },
+  "type": "wordpress-plugin",
+  "require": {
+    "composer/installers": "~1.0"
+   }
+}

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,7 @@ add_filter( 'sitesauce_deployments_get_trigger_on_options_value', 'add_custom_op
 - Trigger on acf/save-post for custom options pages / pages / posts
 - Only trigger once per save
 - Using filters, Sitesauce can be triggered based on custom wp options
+- Add new toggleable fields in the settings menu for new types of triggers
 
 = 1.1 =
 - Fix crash when saving or creating pages

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Sitesauce ===
-Contributors: m1guelpf
+Contributors: m1guelpf, mattpatterson94
 Donate link: https://sitesauce.app/
 Tags: sitesauce, static, jamstack, vercel, zeit
 Requires at least: 4.6
-Tested up to: 5.2.3
+Tested up to: 5.7.2
 Stable tag: 4.3
 Requires PHP: 5.5
 License: GPLv2 or later
@@ -24,11 +24,33 @@ This plugin allows you to integrate your WordPress site with Sitesauce by pingin
 
 == Frequently Asked Questions ==
 
-= Where can I get my Sitesauce build hook URL =
+= Where can I get my Sitesauce build hook URL? =
 
 You can copy your Sitesauce build URL from the settings page on your Sitesauce dashboard.
 
+= How do I trigger Sitesauce when options are updated? =
+
+Be sure you have enabled the "Trigger on Option Updates" setting in the Sitesauce settings in WordPress. 
+
+You can use the `sitesauce_deployments_get_trigger_on_options_value` to add options to watch. For example, add the following to your `functions.php`
+
+```php
+function add_custom_options_to_trigger( $options ) {
+    array_push($options, "some_option");
+
+    return $options;
+}
+
+add_filter( 'sitesauce_deployments_get_trigger_on_options_value', 'add_custom_options_to_trigger' );
+```
+
+
 == Changelog ==
+
+= 1.2 =
+- Trigger on acf/save-post for custom options pages / pages / posts
+- Only trigger once per save
+- Using filters, Sitesauce can be triggered based on custom wp options
 
 = 1.1 =
 - Fix crash when saving or creating pages

--- a/sitesauce.php
+++ b/sitesauce.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * Plugin Name: Sitesauce
- * Description: Keep Sitesauce in sync with your Wordpress content.
+ * Plugin Name: Sitesauce - Extra Saucy 
+ * Description: Keep Sitesauce in sync with your Wordpress content. Based on the official Sitesauce plugin with extra sauce.
  * Author: Miguel Piedrafita
- * Author URI: https://miguelpiedrafita.com
- * Plugin URI: https://sitesauce.app
- * Version: 1.1.0
+ * Author URI: https://mattdoesdev.com
+ * Plugin URI: https://mattdoesdev.com
+ * Version: 1.2.0
  * License: GPL-2.0+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  */

--- a/src/App.php
+++ b/src/App.php
@@ -49,6 +49,7 @@ final class App
     protected function constants()
     {
         define('SITESAUCE_DEPLOYMENTS_OPTIONS_KEY', 'wp_sitesauce_deployments');
+        define('SITESAUCE_DEPLOYMENTS_TRIGGER_OPTIONS_FILTER', 'sitesauce_filter_trigger_options');
     }
 
 	/**

--- a/src/Field.php
+++ b/src/Field.php
@@ -17,4 +17,18 @@ class Field
             <?= !empty($args['description']) ? "<p class=\"description\">{$args['description']}</p>" : ''; ?>
         </div><?php
     }
+
+    /**
+     * Render an input[type=checkbox] field
+     *
+     * @param array $args
+     * @return void
+     */
+    public static function checkbox($args = [])
+    {
+        ?><div>
+            <input type="checkbox" class="regular-text" <?= esc_attr($args['checked']) == "1" ? "checked" : "" ?> name="<?= esc_attr($args['name']); ?>" value="<?= $args['value']; ?>">
+            <?= !empty($args['description']) ? "<p class=\"description\">{$args['description']}</p>" : ''; ?>
+        </div><?php
+    }
 }

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -34,6 +34,20 @@ class Settings
             'placeholder' => 'https://app.sitesauce.app/api/build_hooks/...',
             'description' => 'A build hook for the site you want to keep updated. You can get this value on the settings page of your site.'
         ]);
+
+        add_settings_field('trigger_on_options', 'Trigger on Option Updates', ['Sitesauce\Wordpress\Field', 'checkbox'], $key, 'general', [
+            'name' => "{$key}[trigger_on_options]",
+            'value' => "1",
+            'checked' => sitesauce_deployments_get_trigger_on_options_value() == "1",
+            'description' => 'If you want to trigger Sitesauce on option updates. <a href="https://github.com/mattpatterson94/sitesauce-wordpress-plugin/" target="_blank">Learn more here</a>'
+        ]);
+
+        add_settings_field('trigger_on_acf_save_post', 'Trigger on Advanced Custom Fields Save Hook', ['Sitesauce\Wordpress\Field', 'checkbox'], $key, 'general', [
+            'name' => "{$key}[trigger_on_acf_save_post]",
+            'value' => "1",
+            'checked' => sitesauce_deployments_get_trigger_on_acf_save_post_value() == "1",
+            'description' => 'If you want to trigger Sitesauce on Advanced Custom Fields Hook. <a href="https://www.advancedcustomfields.com/resources/acf-save_post/" target="_blank">Learn more here</a>'
+        ]);
     }
 
     /**

--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -5,6 +5,12 @@ namespace Sitesauce\Wordpress;
 class WebhookTrigger
 {
     /**
+     * Use this to track whether we have already triggered the webhook
+     * This stops the webhook being triggered twice
+    */ 
+    global $triggered = false;
+
+    /**
      * When a post is saved or updated, fire this
      *
      * @param int $id
@@ -39,6 +45,12 @@ class WebhookTrigger
         if (filter_var($hook = sitesauce_deployments_get_build_hook(), FILTER_VALIDATE_URL) === false) {
             return;
         }
+
+        if(self::triggered) {
+            return;
+        }
+
+        self::triggered = true;
 
         return file_get_contents($hook);
     }

--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -36,6 +36,17 @@ class WebhookTrigger
     }
 
     /**
+     * Fires on the ACF Save Post hook
+     * Useful for when ACF is used, and used on Options pages
+     *
+     * @return void
+     */
+    public static function triggerOptionAcfSavePost($post_id)
+    {
+        self::fireWebhook();
+    }
+
+    /**
      * Fire a request to the webhook when a term has been created.
      *
      * @return void

--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -32,7 +32,11 @@ class WebhookTrigger
      */
     public static function triggerOptionAdded($option, $value)
     {
-        $options = apply_filters( 'sitesauce_filter_trigger_options', array() );
+        if(sitesauce_deployments_get_trigger_on_options_value() != "1") {
+           return; 
+        }
+
+        $options = apply_filters( SITESAUCE_DEPLOYMENTS_TRIGGER_OPTIONS_FILTER, array() );
 
         if(in_array($option, $options)) {
             self::fireWebhook();
@@ -46,7 +50,11 @@ class WebhookTrigger
      */
     public static function triggerOptionUpdated($option, $old_value, $value)
     {
-        $options = apply_filters( 'sitesauce_filter_trigger_options', array() );
+        if(sitesauce_deployments_get_trigger_on_options_value() != "1") {
+           return; 
+        }
+
+        $options = apply_filters( SITESAUCE_DEPLOYMENTS_TRIGGER_OPTIONS_FILTER, array() );
 
         if(in_array($option, $options)) {
             self::fireWebhook();
@@ -61,6 +69,10 @@ class WebhookTrigger
      */
     public static function triggerOptionAcfSavePost($post_id)
     {
+        if(sitesauce_deployments_get_trigger_on_acf_save_post_value() != "1") {
+           return; 
+        }
+
         self::fireWebhook();
     }
 

--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -26,6 +26,16 @@ class WebhookTrigger
     }
 
     /**
+     * When an options page is updated, fire this
+     *
+     * @return void
+     */
+    public static function triggerOptionAddedUpdated()
+    {
+        self::fireWebhook();
+    }
+
+    /**
      * Fire a request to the webhook when a term has been created.
      *
      * @return void

--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -8,7 +8,7 @@ class WebhookTrigger
      * Use this to track whether we have already triggered the webhook
      * This stops the webhook being triggered twice
     */ 
-    global $triggered = false;
+    static $triggered = false;
 
     /**
      * When a post is saved or updated, fire this
@@ -26,13 +26,31 @@ class WebhookTrigger
     }
 
     /**
+     * When an options page is added, fire this
+     *
+     * @return void
+     */
+    public static function triggerOptionAdded($option, $value)
+    {
+        $options = apply_filters( 'sitesauce_filter_trigger_options', array() );
+
+        if(in_array($option, $options)) {
+            self::fireWebhook();
+        }
+    }
+
+    /**
      * When an options page is updated, fire this
      *
      * @return void
      */
-    public static function triggerOptionAddedUpdated()
+    public static function triggerOptionUpdated($option, $old_value, $value)
     {
-        self::fireWebhook();
+        $options = apply_filters( 'sitesauce_filter_trigger_options', array() );
+
+        if(in_array($option, $options)) {
+            self::fireWebhook();
+        }
     }
 
     /**
@@ -67,11 +85,11 @@ class WebhookTrigger
             return;
         }
 
-        if(self::triggered) {
+        if(self::$triggered) {
             return;
         }
 
-        self::triggered = true;
+        self::$triggered = true;
 
         return file_get_contents($hook);
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -64,15 +64,15 @@ if (!function_exists('sitesauce_deployments_fire_webhook_save_post')) {
     add_action('save_post', 'sitesauce_deployments_fire_webhook_save_post');
 }
 
-if (!function_exists('sitesauce_deployments_fire_webhook_created_term')) {
+if (!function_exists('sitesauce_deployments_fire_webhook_trashed_post')) {
     /**
      * Fire a request to the webhook when a post is deleted.
      *
      * @return void
      */
-    function sitesauce_deployments_fire_webhook_thrashed_post()
+    function sitesauce_deployments_fire_webhook_trashed_post()
     {
         \Sitesauce\Wordpress\WebhookTrigger::triggerTrashedPost();
     }
-    add_action('thrased_post', 'sitesauce_deployments_fire_webhook_thrashed_post');
+    add_action('trashed_post', 'sitesauce_deployments_fire_webhook_trashed_post');
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -77,18 +77,30 @@ if (!function_exists('sitesauce_deployments_fire_webhook_trashed_post')) {
     add_action('trashed_post', 'sitesauce_deployments_fire_webhook_trashed_post');
 }
 
-if (!function_exists('sitesauce_deployments_fire_webhook_option_added_updated')) {
+if (!function_exists('sitesauce_deployments_fire_webhook_option_updated')) {
     /**
      * Fire a request to the webhook when an option is updated.
      *
      * @return void
      */
-    function sitesauce_deployments_fire_webhook_option_added_updated()
+    function sitesauce_deployments_fire_webhook_option_updated($option, $old_value, $value)
     {
-        \Sitesauce\Wordpress\WebhookTrigger::triggerOptionAddedUpdated();
+        \Sitesauce\Wordpress\WebhookTrigger::triggerOptionUpdated($option, $old_value, $value);
     }
-    add_action('updated_option', 'sitesauce_deployments_fire_webhook_option_added_updated');
-    add_action('added_option', 'sitesauce_deployments_fire_webhook_option_added_updated');
+    add_action('updated_option', 'sitesauce_deployments_fire_webhook_option_updated', 10, 3);
+}
+
+if (!function_exists('sitesauce_deployments_fire_webhook_option_added')) {
+    /**
+     * Fire a request to the webhook when an option is added.
+     *
+     * @return void
+     */
+    function sitesauce_deployments_fire_webhook_option_added($option, $value)
+    {
+        \Sitesauce\Wordpress\WebhookTrigger::triggerOptionAdded($option, $value);
+    }
+    add_action('added_option', 'sitesauce_deployments_fire_webhook_option_added', 10, 2);
 }
 
 if (!function_exists('sitesauce_deployments_fire_webhook_acf_save_post')) {
@@ -98,7 +110,7 @@ if (!function_exists('sitesauce_deployments_fire_webhook_acf_save_post')) {
      * 
      * @return void
      */
-    function sitesauce_deployments_fire_webhook_acf_save_post()
+    function sitesauce_deployments_fire_webhook_acf_save_post($post_id)
     {
         \Sitesauce\Wordpress\WebhookTrigger::triggerOptionAcfSavePost($post_id);
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -26,6 +26,32 @@ if (!function_exists('sitesauce_deployments_get_build_hook')) {
     }
 }
 
+if (!function_exists('sitesauce_deployments_get_trigger_on_options_value')) {
+    /**
+     * Return the trigger on options value
+     *
+     * @return true|false|null
+     */
+    function sitesauce_deployments_get_trigger_on_options_value()
+    {
+        $options = sitesauce_deployments_get_options();
+        return isset($options['trigger_on_options']) ? $options['trigger_on_options'] : null;
+    }
+}
+
+if (!function_exists('sitesauce_deployments_get_trigger_on_acf_save_post_value')) {
+    /**
+     * Return the trigger on options value
+     *
+     * @return true|false|null
+     */
+    function sitesauce_deployments_get_trigger_on_acf_save_post_value()
+    {
+        $options = sitesauce_deployments_get_options();
+        return isset($options['trigger_on_acf_save_post']) ? $options['trigger_on_acf_save_post'] : null;
+    }
+}
+
 if (!function_exists('sitesauce_deployments_fire_webhook')) {
     /**
      * Fire a request to the webhook.

--- a/src/functions.php
+++ b/src/functions.php
@@ -90,3 +90,17 @@ if (!function_exists('sitesauce_deployments_fire_webhook_option_added_updated'))
     add_action('updated_option', 'sitesauce_deployments_fire_webhook_option_added_updated');
     add_action('added_option', 'sitesauce_deployments_fire_webhook_option_added_updated');
 }
+
+if (!function_exists('sitesauce_deployments_fire_webhook_acf_save_post')) {
+    /**
+     * Fire a request to the webhook when an acf page/post is updated.
+     * This is useful for capturing changes to acf options pages, etc.
+     * 
+     * @return void
+     */
+    function sitesauce_deployments_fire_webhook_acf_save_post()
+    {
+        \Sitesauce\Wordpress\WebhookTrigger::triggerOptionAcfSavePost($post_id);
+    }
+    add_action('acf/save_post', 'sitesauce_deployments_fire_webhook_acf_save_post');
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -76,3 +76,17 @@ if (!function_exists('sitesauce_deployments_fire_webhook_trashed_post')) {
     }
     add_action('trashed_post', 'sitesauce_deployments_fire_webhook_trashed_post');
 }
+
+if (!function_exists('sitesauce_deployments_fire_webhook_option_added_updated')) {
+    /**
+     * Fire a request to the webhook when an option is updated.
+     *
+     * @return void
+     */
+    function sitesauce_deployments_fire_webhook_option_added_updated()
+    {
+        \Sitesauce\Wordpress\WebhookTrigger::triggerOptionAddedUpdated();
+    }
+    add_action('updated_option', 'sitesauce_deployments_fire_webhook_option_added_updated');
+    add_action('added_option', 'sitesauce_deployments_fire_webhook_option_added_updated');
+}


### PR DESCRIPTION
### Context

The Sitesauce plugin was lacking a bit of TLC. Mainly that it wasn't configured to trigger on custom options or options pages. 

For my use case, I store a lot of settings in options pages, so if a customer changes say a "restaurant menu" via those options pages the site is not updated.

### Changes

* Fix up a bug with the `trashed_post` hook
* Watch for options updates
* Watch for ACF save post updates for options pages that use acf
* Make options toggleable via the Sitesauce settings
* Bump version to 1.2.0
* Set up composer so I can add this as a composer package

![Screen Shot 2021-09-02 at 10 11 15 am](https://user-images.githubusercontent.com/4578986/131761432-64b9f539-48ce-4d6f-a2a3-a5982d768ca6.jpg)
